### PR TITLE
Pirate Patchers - Issue 12 - Status Bar Toggle On Off

### DIFF
--- a/Status_Bar_ReadMe.md
+++ b/Status_Bar_ReadMe.md
@@ -1,0 +1,8 @@
+# Status Bar
+## Added View Menu with Status Bar checker and Ctrl+B toggle key binding
+
+<img width="903" height="532" alt="image" src="https://github.com/user-attachments/assets/a9ff6227-429f-422e-9306-c2b571536a1c" /> <br>
+*Added View Menu with Status Bar Check* <br
+
+ <img width="904" height="534" alt="image" src="https://github.com/user-attachments/assets/ba5109cf-42bf-4ddd-8cf7-0a23deb8f8a8" /> <br>
+*Status Bar has been toggled off using Ctrl+B* <br>

--- a/src/pynote/utils.py
+++ b/src/pynote/utils.py
@@ -7,6 +7,7 @@ import os
 import json
 from pathlib import Path
 
+#utils exists we need this
 
 def get_config_dir():
     """


### PR DESCRIPTION
Fixed #12 

Pirate Patchers

Status Bar Toggle On and Off
- Added shortcut Ctrl + B
- State persistence is added in create widgets
- Added view menu
- I wrote all the comments myself its not AI
- See Status_Bar_ReadMe

<img width="904" height="533" alt="image" src="https://github.com/user-attachments/assets/c5c7dcc7-43f0-47f1-8db4-c8f369a12f13" /> <br>
<img width="904" height="534" alt="image" src="https://github.com/user-attachments/assets/d4fe1e71-c056-4891-a872-7fb971fb1d28" /> <br>





