### PR TITLE
Pirate Patchers - Issue 11 - Adding Help Menu for Shortcuts

### DIFF
--- a/Help_Shortcuts_ReadMe.md
+++ b/Help_Shortcuts_ReadMe.md
@@ -1,0 +1,7 @@
+# Add Help Menu for Shortcuts
+## changes ui.py and main.py
+
+<img width="316" height="115" alt="image" src="https://github.com/user-attachments/assets/a2e84fd2-5ff8-46be-ada4-71bf0c757685" /> <br>
+*Help Menu* <br>
+<img width="590" height="490" alt="image" src="https://github.com/user-attachments/assets/e4161d33-9ea1-44e2-898a-d48002c63b46" /> <br>
+*Dialog Box with categorized Shortcuts* <br>

--- a/src/pynote/main.py
+++ b/src/pynote/main.py
@@ -2,6 +2,8 @@
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
+from ui import show_shortcuts #imported the shortcuts showing dialog box
+
 APP_TITLE = "PyNote"
 
 
@@ -43,6 +45,13 @@ class PyNoteApp(tk.Tk):
         filemenu.add_separator()
         filemenu.add_command(label='Exit', command=self.quit)
         menu.add_cascade(label='File', menu=filemenu)
+        menu.add_cascade(label="Edit", menu=editmenu)
+        helpmenu = tk.Menu(menu, tearoff=0) #added the help menu
+        helpmenu.add_command(
+            label="Keyboard Shortcuts",
+            command=lambda: show_shortcuts(self)
+        )
+        menu.add_cascade(label="Help", menu=helpmenu)
         self.config(menu=menu)
 
     def _bind_shortcuts(self):

--- a/src/pynote/ui.py
+++ b/src/pynote/ui.py
@@ -2,10 +2,13 @@
 """
 UI components (menus, dialogs) for PyNote.
 """
+import sys #added this for the cross-platform thingie
 
 import tkinter as tk
 from tkinter import messagebox, simpledialog
 
+def shortcut_key(): ##cross platform retrn value
+    return "Cmd" if sys.platform == "darwin" else "Ctrl"
 
 class AboutDialog:
     """About dialog for PyNote."""
@@ -105,6 +108,63 @@ class GoToLineDialog:
                 )
         except ValueError:
             messagebox.showerror('Error', 'Please enter a valid number')
+
+class ShortcutGuideDialog: ### Dialog Box of Shortcuts
+
+    def __init__(self, parent):
+        self.parent = parent
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Keyboard Shortcuts")
+        self.dialog.geometry("420x320")
+        self.dialog.resizable(False, False)
+        self._create_widgets()
+
+    def _create_widgets(self):
+        key = shortcut_key()
+
+        container = tk.Frame(self.dialog, padx=15, pady=10)
+        container.pack(fill="both", expand=True)
+
+        def section(title):
+            tk.Label(
+                container,
+                text=title,
+                font=("Arial", 11, "bold")
+            ).pack(anchor="w", pady=(10, 4))
+
+        def item(name, combo):
+            tk.Label(
+                container,
+                text=f"{name:<20} {combo}",
+                font=("Courier New", 10)
+            ).pack(anchor="w")
+
+        # File Shortcuts
+        section("File")
+        item("New File", f"{key}+N")
+        item("Open File", f"{key}+O")
+        item("Save", f"{key}+S")
+        item("Save As", f"{key}+Shift+S")
+
+        # Editing Shortcuts
+        section("Edit")
+        item("Undo", f"{key}+Z")
+        item("Redo", f"{key}+Y")
+        item("Find", f"{key}+F")
+
+        # View Shortcuts
+        section("View")
+        item("Toggle Status Bar", f"{key}+B")
+
+        tk.Button(
+            container,
+            text="Close",
+            width=10,
+            command=self.dialog.destroy
+        ).pack(pady=15)
+
+def show_shortcuts(parent): #to show the dialog box
+    ShortcutGuideDialog(parent)
 
 
 def show_about(parent):


### PR DESCRIPTION
FIxed #11 

Pirate Patchers

- Help Menu
- Help Dialog Box that lists shortcuts and 
- Organized by category
- Platform specific added using import sys

Also added screenshots to Help_Menu_ReadMe

<img width="316" height="115" alt="image" src="https://github.com/user-attachments/assets/f4a2d489-387d-4927-b0cb-faa43a5d6a08" /> <br>
<img width="590" height="490" alt="image" src="https://github.com/user-attachments/assets/003d8f9a-8062-4b2b-b9b9-752de8203440" />
