### PR TITLE
Pirate Patchers - Issue 9 - Preferences Tab Width

### DIFF
--- a/Tab_Width_ReadMe.md
+++ b/Tab_Width_ReadMe.md
@@ -1,0 +1,14 @@
+# Tab Width
+
+## Added Preferences Menu
+<img width="226" height="114" alt="image" src="https://github.com/user-attachments/assets/b7220d65-defe-4600-802c-08ab78c92c34" /> <br>
+## Dialog Box with Radio Button Options
+<img width="435" height="317" alt="image" src="https://github.com/user-attachments/assets/34876b3d-899b-4f2b-9279-4db1c4af9f63" /> <br>
+### 2 width
+<img width="201" height="63" alt="image" src="https://github.com/user-attachments/assets/8a34b1c5-cf5b-4ef6-8e8d-cab4fb7bf2d9" /><br>
+### 4 width
+<img width="194" height="67" alt="image" src="https://github.com/user-attachments/assets/a34d2ed2-35ab-46cb-b23e-fa29666a640a" /><br>
+### 8 width
+<img width="219" height="76" alt="image" src="https://github.com/user-attachments/assets/e07a51d2-a40f-4abe-97ba-3564d201a5d0" />
+
+

--- a/src/pynote/ui.py
+++ b/src/pynote/ui.py
@@ -111,3 +111,46 @@ def show_about(parent):
     """Show about dialog."""
     AboutDialog(parent)
 
+class PreferencesDialog: #Preferences DIalog box to choose width
+    def __init__(self, parent, settings, on_apply):
+        self.parent = parent
+        self.settings = settings
+        self.on_apply = on_apply
+
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Preferences")
+        self.dialog.geometry("260x160")
+        self.dialog.resizable(False, False)
+
+        self.tab_size = tk.IntVar(value=settings.get('tab_size', 4))
+
+        self._build_ui()
+
+    def _build_ui(self):
+        frame = tk.Frame(self.dialog, padx=10, pady=10)
+        frame.pack(fill="both", expand=True)
+
+        tk.Label(frame, text="Tab width (spaces):").pack(anchor="w")
+
+        for size in (2, 4, 8):
+            tk.Radiobutton(
+                frame,
+                text=str(size),
+                variable=self.tab_size,
+                value=size
+            ).pack(anchor="w")
+
+        tk.Button(
+            frame,
+            text="Apply",
+            width=10,
+            command=self._apply
+        ).pack(pady=10)
+
+    def _apply(self):
+        self.settings['tab_size'] = self.tab_size.get()
+        self.on_apply(self.tab_size.get())
+        self.dialog.destroy()
+
+def show_preferences(parent, settings, on_apply): ## to apply the preferences
+    PreferencesDialog(parent, settings, on_apply)

--- a/src/pynote/ui.py
+++ b/src/pynote/ui.py
@@ -6,7 +6,6 @@ UI components (menus, dialogs) for PyNote.
 import tkinter as tk
 from tkinter import messagebox, simpledialog
 
-
 class AboutDialog:
     """About dialog for PyNote."""
     

--- a/src/pynote/utils.py
+++ b/src/pynote/utils.py
@@ -2,6 +2,7 @@
 """
 Utility functions for PyNote editor.
 """
+#yes util does exist we need the load and save settings for preferences across all sessions
 
 import os
 import json


### PR DESCRIPTION
Fixed #9 

Pirate Patchers

- Created preferences menu <br> 
- <img width="226" height="114" alt="image" src="https://github.com/user-attachments/assets/74591185-4ab9-490f-adf2-2f0bee3376bd" /> <br>
- Preferences Setting available tab width apply persistence dialog box 
- <img width="435" height="317" alt="image" src="https://github.com/user-attachments/assets/9a2923a0-836a-4db1-9dc5-9390c3eefdb6" />
<br>

   - 2 <img width="201" height="63" alt="image" src="https://github.com/user-attachments/assets/033aec98-f9dc-40f9-9c93-f556bf48fd9d" />
 -4  <img width="194" height="67" alt="image" src="https://github.com/user-attachments/assets/0e634091-cd47-4021-b2dd-88b121b819f1" />

 - 8 <img width="219" height="76" alt="image" src="https://github.com/user-attachments/assets/f1c2429e-2512-4d10-901a-58c41a0ac8d4" />

- Screenshots are also in the readme

