### PR TITLE
Pirate Patchers - Issue 8 - Recent Files

### DIFF
--- a/Recent_files_ReadMe.md
+++ b/Recent_files_ReadMe.md
@@ -1,0 +1,11 @@
+# Recent Files, Upto Five
+
+## Recent Files DropBox
+- It displays filename not just the path name now ehhehehe <br>
+<img width="294" height="153" alt="image" src="https://github.com/user-attachments/assets/06d8a18f-0345-4bb5-ab31-3373384369b1" /> <br>
+
+## Buffer of 5 Files <br>
+- <img width="295" height="170" alt="image" src="https://github.com/user-attachments/assets/674c8d1c-514c-4cb9-8072-4b112189a945" /> <br>
+- <img width="273" height="171" alt="image" src="https://github.com/user-attachments/assets/c6bd61cd-19f0-4832-a5cf-037a278b05c3" />
+
+

--- a/src/pynote/utils.py
+++ b/src/pynote/utils.py
@@ -3,6 +3,8 @@
 Utility functions for PyNote editor.
 """
 
+#dont forget about utils we need it chat
+
 import os
 import json
 from pathlib import Path


### PR DESCRIPTION
Fixed #8 

Pirate Patchers

## Added a recent files menu 
- <img width="294" height="153" alt="image" src="https://github.com/user-attachments/assets/cac5adef-cb8d-450f-8a70-5b46225ff3ec" /> <br>
## Buffer of 5 files
<img width="295" height="170" alt="image" src="https://github.com/user-attachments/assets/5a055c71-ee28-4004-9a96-a9b97628d0ae" /> <br>
<img width="273" height="171" alt="image" src="https://github.com/user-attachments/assets/43bd8a89-aa45-4a9c-9938-41e197850fde" /> <br>
## Opens files when u click on it in recent menu
<img width="288" height="159" alt="image" src="https://github.com/user-attachments/assets/0c72950b-24b6-4661-b227-f54714188fbc" /> <br>

- And also added screenshots in the Recent_Files_ReadMe