### PR TITLE
Pirate Patchers - Issue 10 - Find_Dialog_Box

### DIFF
--- a/Find_ReadMe.md
+++ b/Find_ReadMe.md
@@ -1,0 +1,11 @@
+# Find Option
+
+## Find Dialog Box with case Sensitive
+
+<img width="552" height="299" alt="image" src="https://github.com/user-attachments/assets/897a3723-de4c-48ea-8dfd-b23cfca6cd49" /> <br>
+
+<br>
+<img width="568" height="274" alt="image" src="https://github.com/user-attachments/assets/992f418d-c4ab-46f5-a7f4-f79c1ef0a6b8" />
+<br>
+<img width="554" height="286" alt="image" src="https://github.com/user-attachments/assets/05b47b19-8e3e-4c51-bb3f-ff5b633b3826" />
+

--- a/src/pynote/main.py
+++ b/src/pynote/main.py
@@ -4,7 +4,7 @@ from tkinter import filedialog, messagebox, ttk
 
 APP_TITLE = "PyNote"
 
-from ui import show_find_dialog #import the dialog
+from ui import FindDialog,show_find_dialog #import the dialog
 
 class PyNoteApp(tk.Tk):
     def __init__(self):
@@ -54,13 +54,31 @@ class PyNoteApp(tk.Tk):
         menu.add_cascade(label="Edit", menu=editmenu)
         self.config(menu=menu)
 
+    def open_find_dialog(self): #find the dialog and check params
+        if self.find_dialog:
+            try:
+                self.find_dialog.dialog.lift()
+                self.find_dialog.dialog.focus_force()
+            except Exception:
+                self.find_dialog = None
+            return
+
+        self.find_dialog = FindDialog(
+            self,
+            self.text,
+            on_close=self._on_find_dialog_close
+        )
+
+    def _on_find_dialog_close(self): #and then close
+        self.find_dialog = None
+    
     def _bind_shortcuts(self):
         self.bind('<Control-s>', lambda e: self.save_file())
         self.bind('<Control-o>', lambda e: self.open_file())
         self.bind('<Control-n>', lambda e: self.new_file())
         self.bind('<Control-z>', lambda e: self.text.event_generate('<<Undo>>'))
         self.bind('<Control-y>', lambda e: self.text.event_generate('<<Redo>>'))
-        self.bind('<Control-f>', lambda e: show_find_dialog(self, self.text)) #ctrl f key binding
+        self.bind('<Control-f>', lambda e: self.open_find_dialog()) #ctrl f key binding #different lambda for only 1 dialog box
 
     def new_file(self):
         if self._confirm_discard():

--- a/src/pynote/main.py
+++ b/src/pynote/main.py
@@ -4,6 +4,7 @@ from tkinter import filedialog, messagebox, ttk
 
 APP_TITLE = "PyNote"
 
+from ui import show_find_dialog #import the dialog
 
 class PyNoteApp(tk.Tk):
     def __init__(self):
@@ -43,6 +44,14 @@ class PyNoteApp(tk.Tk):
         filemenu.add_separator()
         filemenu.add_command(label='Exit', command=self.quit)
         menu.add_cascade(label='File', menu=filemenu)
+        editmenu = tk.Menu(menu, tearoff=0) ## Adding edit menu for the find dialog boxie
+        editmenu.add_command(
+            label="Find",
+            accelerator="Ctrl+F",
+            command=lambda: show_find_dialog(self, self.text)
+        )
+
+        menu.add_cascade(label="Edit", menu=editmenu)
         self.config(menu=menu)
 
     def _bind_shortcuts(self):
@@ -51,6 +60,7 @@ class PyNoteApp(tk.Tk):
         self.bind('<Control-n>', lambda e: self.new_file())
         self.bind('<Control-z>', lambda e: self.text.event_generate('<<Undo>>'))
         self.bind('<Control-y>', lambda e: self.text.event_generate('<<Redo>>'))
+        self.bind('<Control-f>', lambda e: show_find_dialog(self, self.text)) #ctrl f key binding
 
     def new_file(self):
         if self._confirm_discard():

--- a/src/pynote/ui.py
+++ b/src/pynote/ui.py
@@ -108,12 +108,14 @@ class GoToLineDialog:
 
 class FindDialog: #Find Dialog Box Moment
 
-    def __init__(self, parent, text_widget):
+    def __init__(self, parent, text_widget,on_close=None): #added on-close for only 1 dialog box of find
+        self.on_close = on_close #
         self.parent = parent
         self.text = text_widget
         self.last_index = "1.0"
 
         self.dialog = tk.Toplevel(parent)
+        self.dialog.protocol("WM_DELETE_WINDOW", self._close) # handle close event 
         self.dialog.title("Find")
         self.dialog.geometry("320x160")
         self.dialog.resizable(False, False)

--- a/src/pynote/ui.py
+++ b/src/pynote/ui.py
@@ -106,7 +106,90 @@ class GoToLineDialog:
         except ValueError:
             messagebox.showerror('Error', 'Please enter a valid number')
 
+class FindDialog: #Find Dialog Box Moment
 
+    def __init__(self, parent, text_widget):
+        self.parent = parent
+        self.text = text_widget
+        self.last_index = "1.0"
+
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Find")
+        self.dialog.geometry("320x160")
+        self.dialog.resizable(False, False)
+
+        self.find_var = tk.StringVar()
+        self.case_sensitive = tk.BooleanVar()
+
+        self._build_ui()
+
+    def _build_ui(self):
+        frame = tk.Frame(self.dialog, padx=10, pady=10)
+        frame.pack(fill="both", expand=True)
+
+        tk.Label(frame, text="Find:").grid(row=0, column=0, sticky="w")
+        entry = tk.Entry(frame, textvariable=self.find_var, width=28)
+        entry.grid(row=0, column=1, columnspan=2, pady=5)
+        entry.focus()
+
+        tk.Checkbutton(
+            frame, text="Case sensitive", variable=self.case_sensitive
+        ).grid(row=1, column=1, sticky="w")
+
+        tk.Button(frame, text="Next", width=8, command=self.find_next).grid(
+            row=2, column=1, pady=10
+        )
+        tk.Button(frame, text="Previous", width=8, command=self.find_prev).grid(
+            row=2, column=2, pady=10
+        )
+
+    #find logiks moment
+
+    def _search(self, backwards=False):
+        term = self.find_var.get()
+        if not term:
+            return
+
+        self.text.tag_remove("find_highlight", "1.0", tk.END)
+
+        flags = {}
+        if not self.case_sensitive.get():
+            flags["nocase"] = True
+
+        start = self.last_index
+        if backwards:
+            start = self.text.index(f"{start} -1c")
+
+        pos = self.text.search(
+            term,
+            start,
+            stopindex=tk.END if not backwards else "1.0",
+            backwards=backwards,
+            **flags
+        )
+
+        if not pos:
+            self.last_index = "1.0"
+            return
+
+        end = f"{pos}+{len(term)}c"
+        self.text.tag_add("find_highlight", pos, end)
+        self.text.tag_config("find_highlight", background="yellow")
+
+        self.text.mark_set(tk.INSERT, end)
+        self.text.see(pos)
+
+        self.last_index = end
+
+    def find_next(self):
+        self._search(backwards=False)
+
+    def find_prev(self):
+        self._search(backwards=True)
+
+def show_find_dialog(parent, text_widget): ## to call the find 
+    FindDialog(parent, text_widget)
+    
 def show_about(parent):
     """Show about dialog."""
     AboutDialog(parent)


### PR DESCRIPTION
Fixed #10 
Pirate Patchers

- Ctrl+F opens find dialog
- Found term highlighted and focused
- Can navigate to next/previous matches
- Case-sensitive option
- Added screenshots to Find_ReadMe also


# Previous Issue Fix 
<img width="699" height="174" alt="image" src="https://github.com/user-attachments/assets/a2c56dd0-6ca7-4778-9e85-6fdb6cee186f" /> <br>

- Added on_close param in ui and protocol("WM_DELETE_WINDOW")
- Added open_find_dialog function in main

# Screenshots

<img width="552" height="299" alt="image" src="https://github.com/user-attachments/assets/76f87319-bf32-4884-98ea-30354c5a40f3" /> <br>
<img width="568" height="274" alt="image" src="https://github.com/user-attachments/assets/6c80b1ec-a4e0-4960-88b0-26e0e704f84a" /> <br>

<img width="554" height="286" alt="image" src="https://github.com/user-attachments/assets/a4884365-10bd-48cd-858b-90407d5ff6f0" />